### PR TITLE
Integration with MardownEdit's pandoc variant.

### DIFF
--- a/Keymap/Default (OSX).sublime-keymap
+++ b/Keymap/Default (OSX).sublime-keymap
@@ -2,25 +2,29 @@
   { "keys": ["super+alt+r"],
     "command":"pandoc_convertor",
     "args":{"openAfter":true,   "target":"html"},
-    "context":[{"key": "selector", "operator": "equal", "operand": "text.pandoc" }]},
-
+    "context":[{"key": "selector", "operator": "equal", 
+                "regex_match": "text.pandoc|text.html.markdown.pandoc", "match_all": true}]},
   { "keys": ["super+alt+h"],
     "command":"pandoc_convertor",
     "args":{"openAfter":false,  "target":"html"},
-    "context":[{"key": "selector", "operator": "equal", "operand": "text.pandoc" }]},
+    "context":[{"key": "selector", "operator": "equal", 
+                "regex_match": "text.pandoc|text.html.markdown.pandoc", "match_all": true}]},
 
   { "keys": ["super+alt+d"],
     "command":"pandoc_convertor",
     "args":{"openAfter":false,   "target":"docx"},
-    "context":[{"key": "selector", "operator": "equal", "operand": "text.pandoc" }]},
+    "context":[{"key": "selector", "operator": "equal", 
+                "regex_match": "text.pandoc|text.html.markdown.pandoc", "match_all": true}]},
 
   { "keys": ["super+alt+b"],
     "command":"pandoc_convertor",
     "args":{"openAfter":false,   "target":"beamer"},
-    "context":[{"key": "selector", "operator": "equal", "operand": "text.pandoc" }]},
+    "context":[{"key": "selector", "operator": "equal", 
+                "regex_match": "text.pandoc|text.html.markdown.pandoc", "match_all": true}]},
 
   { "keys": ["super+shift+alt+p"],
     "command":"pandoc_convertor",
     "args":{"openAfter":false,   "target":"pdf"},
-    "context":[{"key": "selector", "operator": "equal", "operand": "text.pandoc" }]}
+    "context":[{"key": "selector", "operator": "equal", 
+                "regex_match": "text.pandoc|text.html.markdown.pandoc", "match_all": true}]},
 ]

--- a/Keymap/Default.sublime-keymap
+++ b/Keymap/Default.sublime-keymap
@@ -2,24 +2,29 @@
   { "keys": ["ctrl+alt+h"],
     "command":"pandoc_convertor",
     "args":{"target":"html"},
-    "context":[{"key": "selector", "operator": "equal", "operand": "text.pandoc" }]},
+    "context":[{"key": "selector", "operator": "equal", 
+                "regex_match": "text.pandoc|text.html.markdown.pandoc", "match_all": true}]},
 
   { "keys": ["ctrl+alt+d"],
     "command":"pandoc_convertor",
     "args":{"target":"docx"},
-    "context":[{"key": "selector", "operator": "equal", "operand": "text.pandoc" }]},
+    "context":[{"key": "selector", "operator": "equal", 
+                "regex_match": "text.pandoc|text.html.markdown.pandoc", "match_all": true}]},
 
   { "keys": ["ctrl+alt+b"],
     "command":"pandoc_convertor",
     "args":{"target":"beamer"},
-    "context":[{"key": "selector", "operator": "equal", "operand": "text.pandoc" }]},
+    "context":[{"key": "selector", "operator": "equal", 
+                "regex_match": "text.pandoc|text.html.markdown.pandoc", "match_all": true}]},
 
   { "keys": ["ctrl+alt+c"],
     "command":"pandoc_convertor",
     "args":{"target":"pdf"},
-    "context":[{"key": "selector", "operator": "equal", "operand": "text.pandoc" }]},
+    "context":[{"key": "selector", "operator": "equal", 
+                "regex_match": "text.pandoc|text.html.markdown.pandoc", "match_all": true}]},
 
   { "keys": ["ctrl+alt+shift+t"],
     "command":"pandoc_table",
-    "context":[{"key": "selector", "operator": "equal", "operand": "text.pandoc" }]}
+    "context":[{"key": "selector", "operator": "equal", 
+                "regex_match": "text.pandoc|text.html.markdown.pandoc", "match_all": true}]}
 ]

--- a/PandocConvertor.py
+++ b/PandocConvertor.py
@@ -43,6 +43,7 @@ class PandocConvertorCommand(sublime_plugin.TextCommand):
     def is_enabled(self):
         if self.view.score_selector(0, "text.pandoc") > 0 or \
             self.view.score_selector(0, "text.html.markdown") > 0 or \
+            self.view.score_selector(0, "text.html.markdown.pandoc") > 0 or \
             self.view.score_selector(0, "text.html.markdown.multimarkdown") > 0:
             return True
 

--- a/Snippets/pandoc_bib.sublime-snippet
+++ b/Snippets/pandoc_bib.sublime-snippet
@@ -3,6 +3,6 @@
 <!-- [[BIB]] [[BIBSTYLE=${1:add a style name}]] --> ${2}
 ]]></content>
     <tabTrigger>bib</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Add the option to handle bibliography and its style</description>
 </snippet>

--- a/Snippets/pandoc_bold.sublime-snippet
+++ b/Snippets/pandoc_bold.sublime-snippet
@@ -3,6 +3,6 @@
 **${1:words in bold}** ${2}
 ]]></content>
     <tabTrigger>bo</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Bold style</description>
 </snippet>

--- a/Snippets/pandoc_citation.sublime-snippet
+++ b/Snippets/pandoc_citation.sublime-snippet
@@ -3,6 +3,6 @@
 [${1:prefix}@${2:CitationKey}] ${3}
 ]]></content>
     <tabTrigger>ci</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Add a complete citation</description>
 </snippet>

--- a/Snippets/pandoc_class.sublime-snippet
+++ b/Snippets/pandoc_class.sublime-snippet
@@ -3,6 +3,6 @@
 <!-- [[CLASS=${1}]] --> ${2}
 ]]></content>
     <tabTrigger>class</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Add the option to add a custom LaTeX class</description>
 </snippet>

--- a/Snippets/pandoc_comment.sublime-snippet
+++ b/Snippets/pandoc_comment.sublime-snippet
@@ -3,6 +3,6 @@
 <!-- ${1:Your comment} --> ${2}
 ]]></content>
     <tabTrigger>co</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Add a comment</description>
 </snippet>

--- a/Snippets/pandoc_footnote.sublime-snippet
+++ b/Snippets/pandoc_footnote.sublime-snippet
@@ -4,6 +4,6 @@
 [^${1:Nber}]: ${2:Note}. ${3}
 ]]></content>
     <tabTrigger>not</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Quickly add a footnote</description>
 </snippet>

--- a/Snippets/pandoc_header.sublime-snippet
+++ b/Snippets/pandoc_header.sublime-snippet
@@ -3,6 +3,6 @@
 <!-- [[HEADER]] --> ${1}
 ]]></content>
     <tabTrigger>head</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Header option to add custom preambule instructions to the Beamer file</description>
 </snippet>

--- a/Snippets/pandoc_heading.sublime-snippet
+++ b/Snippets/pandoc_heading.sublime-snippet
@@ -6,6 +6,6 @@
 ${4}
 ]]></content>
     <tabTrigger>%%</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Add the heading of the file</description>
 </snippet>

--- a/Snippets/pandoc_image.sublime-snippet
+++ b/Snippets/pandoc_image.sublime-snippet
@@ -3,6 +3,6 @@
 ![](${1:link_to_the_file} "Figure ${2:Nber}: ${3:Title}") ${4}
 ]]></content>
     <tabTrigger>img</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Quickly add a picture</description>
 </snippet>

--- a/Snippets/pandoc_italic.sublime-snippet
+++ b/Snippets/pandoc_italic.sublime-snippet
@@ -3,6 +3,6 @@
 *${1:words in italic}* ${2}
 ]]></content>
     <tabTrigger>it</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Italic style</description>
 </snippet>

--- a/Snippets/pandoc_math.sublime-snippet
+++ b/Snippets/pandoc_math.sublime-snippet
@@ -3,6 +3,6 @@
 \$${1}\$ ${2}
 ]]></content>
     <tabTrigger>mat</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Math based on LaTeX definition</description>
 </snippet>

--- a/Snippets/pandoc_mathml.sublime-snippet
+++ b/Snippets/pandoc_mathml.sublime-snippet
@@ -3,6 +3,6 @@
 <!-- [[MATH]] --> ${1}
 ]]></content>
     <tabTrigger>mathml</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Let pandoc render with the -m option for latexmathml</description>
 </snippet>

--- a/Snippets/pandoc_norender.sublime-snippet
+++ b/Snippets/pandoc_norender.sublime-snippet
@@ -3,6 +3,6 @@
 <!-- [[NORENDER]] --> ${1}
 ]]></content>
     <tabTrigger>rend</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Disable the automatic launch of the file-associated program</description>
 </snippet>

--- a/Snippets/pandoc_power.sublime-snippet
+++ b/Snippets/pandoc_power.sublime-snippet
@@ -3,6 +3,6 @@
 \$\eta^2\$~partial~\$=${1}\$ ${2}
 ]]></content>
     <tabTrigger>pow</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Add eta-squared abbreviation based n LaTeX definition</description>
 </snippet>

--- a/Snippets/pandoc_table.sublime-snippet
+++ b/Snippets/pandoc_table.sublime-snippet
@@ -5,6 +5,6 @@ Table ${1:Nber}: ${2:Title}.
 ![](${3:link_to_the_file}) ${4}
 ]]></content>
     <tabTrigger>tab</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Quickly add a table</description>
 </snippet>

--- a/Snippets/pandoc_template.sublime-snippet
+++ b/Snippets/pandoc_template.sublime-snippet
@@ -3,6 +3,6 @@
 <!-- [[DOCSTYLE=${1:choose a template name}]] --> ${2}
 ]]></content>
     <tabTrigger>temp</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Add the option to choose a template style</description>
 </snippet>

--- a/Snippets/pandoc_toc.sublime-snippet
+++ b/Snippets/pandoc_toc.sublime-snippet
@@ -3,6 +3,6 @@
 <!-- [[TOC]] --> ${1}
 ]]></content>
     <tabTrigger>toc</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Add the option to add a table of content</description>
 </snippet>

--- a/Snippets/pandoc_weblink.sublime-snippet
+++ b/Snippets/pandoc_weblink.sublime-snippet
@@ -3,6 +3,6 @@
 [${1:link}](http://${2:url} "${3:title}")${4}
 ]]></content>
     <tabTrigger>link</tabTrigger>
-    <scope>text.pandoc</scope>
+    <scope>text.pandoc, text.html.markdown.pandoc</scope>
     <description>Add a website link</description>
 </snippet>

--- a/Table_pandoc.py
+++ b/Table_pandoc.py
@@ -14,6 +14,7 @@ class PandocTableCommand(sublime_plugin.TextCommand):
     def is_enabled(self):
         if self.view.score_selector(0, "text.pandoc") > 0 or \
             self.view.score_selector(0, "text.html.markdown") > 0 or \
+            self.view.score_selector(0, "text.html.markdown.pandoc") > 0 or \
             self.view.score_selector(0, "text.html.markdown.multimarkdown") > 0:
             return True
 


### PR DESCRIPTION
Changed scope/context so that all the nice functionalities
of this module could also be used when selected syntax
is MarkdownEdit's pandoc variant, namely: 
`text.html.markdown.pandoc`.